### PR TITLE
Clarify post‑v1 scope in release readiness and mobile architecture docs

### DIFF
--- a/ketchup-prototype-mobile-clean/RELEASE_READINESS.md
+++ b/ketchup-prototype-mobile-clean/RELEASE_READINESS.md
@@ -10,13 +10,13 @@
 ## Privacy disclosure and permissions copy
 - **Privacy disclosure (store listing/app settings)**:
   - We only collect what we need to make the app work.
-  - Your contacts stay on your device unless you enable cloud sync.
+  - Your contacts stay on your device (cloud sync is **post-v1**).
   - We do not sell your data or share it with third parties for advertising.
-  - You can request deletion of synced data at any time.
+  - You can request deletion of synced data at any time (**post-v1**).
 - **Permissions copy**:
   - **Contacts**: “Allow Ketchup to access your contacts to show who you can keep up with. Contacts stay on your device unless you enable sync.”
-  - **Notifications**: “Enable notifications to get reminders when it’s time to catch up.”
-  - **Camera (optional, profile photo)**: “Allow camera access to take a profile photo. Photos are stored locally unless you enable sync.”
+  - **Notifications (post-v1)**: “Enable notifications to get reminders when it’s time to catch up.”
+  - **Camera (optional, profile photo)**: “Allow camera access to take a profile photo. Photos are stored locally (cloud sync is **post-v1**).”
 
 ## Build signing steps
 - **iOS**:
@@ -32,12 +32,12 @@
   4) Upload the AAB to Google Play Console.
 
 ## Internal testing steps
-1) Run a smoke test on iOS and Android devices (or emulators) to verify onboarding, swipe interactions, and reminder flows.
+1) Run a smoke test on iOS and Android devices (or emulators) to verify onboarding, swipe interactions, and list management flows.
 2) Verify permission prompts show the correct copy and that deny/allow paths behave as expected.
-3) Test sync off/on flows to confirm data stays local unless enabled.
+3) Test sync off/on flows to confirm data stays local unless enabled (**post-v1**).
 4) Check UI layout on small and large screens (iPhone SE-class and large Android).
 5) Verify offline behavior for core screens and graceful handling when network is unavailable.
-6) Confirm notifications fire using a short reminder interval.
+6) Confirm notifications fire using a short reminder interval (**post-v1**).
 
 ## Feedback collection plan
 - **Internal testers**: Recruit 5–10 testers with a mix of heavy/light contact lists.

--- a/ketchup-prototype-mobile-clean/docs/mobile-architecture.md
+++ b/ketchup-prototype-mobile-clean/docs/mobile-architecture.md
@@ -21,7 +21,7 @@
   - Stores user preferences, onboarding completion, and cached “recently viewed” contact IDs.
 - **Structured / Offline Cache:** SQLite (via `expo-sqlite`)
   - Stores contact metadata, interaction history, tags, and “swipe decisions.”
-  - Enables fast querying for “Up Next” and analytics without network dependency.
+  - Enables fast querying for analytics without network dependency (“Up Next” is **post-v1**).
 
 ## Navigation Structure
 - **Library:** `@react-navigation/native`
@@ -31,10 +31,10 @@
     - `Main` (tab)
   - **Main Tabs**
     - `Home` (swipe cards)
-    - `Up Next` (queued contacts list)
+    - `Lists` (list management)
     - `Profile/Settings`
   - **Nested Details**
-    - `ContactDetail` pushed from Home/Up Next
+    - `ContactDetail` pushed from Home/Lists
 
 ## Swipe UI Library
 - **Recommendation:** `react-native-gesture-handler` + `react-native-reanimated` (custom swipe card)
@@ -50,12 +50,12 @@
    |
    |-- UI Layer
    |     |-- Swipe Deck (gesture-handler + reanimated)
-   |     |-- Up Next List
+   |     |-- List Management
    |     |-- Contact Detail
    |
    |-- Navigation Layer (@react-navigation)
    |     |-- Root Stack (Onboarding -> Main Tabs)
-   |     |-- Tabs (Home | Up Next | Settings)
+   |     |-- Tabs (Home | Lists | Settings)
    |
    |-- Data Layer
    |     |-- Contact Service (expo-contacts)
@@ -63,6 +63,6 @@
    |           |-- AsyncStorage (prefs, flags)
    |           |-- SQLite (contacts, interactions)
    |
-   |-- Optional Cloud Sync
+   |-- Optional Cloud Sync (**post-v1**)
          |-- Supabase (auth + sync when online)
 ```


### PR DESCRIPTION
### Motivation
- Clearly separate v1 scope from planned features by marking notifications, cloud sync, and the “Up Next” UX as post‑v1 to avoid ambiguity during release prep. 
- Ensure the navigation diagram and testing guidance reflect only v1 screens (onboarding, swipe deck/home, and list management).

### Description
- Updated `RELEASE_READINESS.md` to label cloud sync and notification items as **post‑v1**, adjust permission copy, and change smoke-test guidance to verify onboarding, swipe interactions, and list management flows. 
- Updated `docs/mobile-architecture.md` to remove the `Up Next` tab from the v1 navigation and replace it with `Lists` (list management), update the UI/navigation text diagram to `Home | Lists | Settings`, and mark optional cloud sync as **post‑v1**. 
- Minor copy changes to make the post‑v1 status explicit for camera and synced data deletion references.

### Testing
- No automated tests were run because this is a docs‑only change; verification consisted of reviewing the updated `RELEASE_READINESS.md` and `docs/mobile-architecture.md` content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a677faf4c832d8ff4a796a2e47674)