### PR TITLE
Add app_version, platform, and device_os_version to analytics common fields

### DIFF
--- a/ketchup-prototype-mobile-clean/ANALYTICS_SPEC.md
+++ b/ketchup-prototype-mobile-clean/ANALYTICS_SPEC.md
@@ -7,12 +7,15 @@
 | `user_id` | string | **Required** | Stable, app-level user identifier. Use the authenticated user ID if available; otherwise a temporary anonymous ID that later resolves to the user. |
 | `session_id` | string | **Required** | Unique per app session (e.g., UUID). Regenerate on cold start or after inactivity timeout. |
 | `timestamp` | string (ISO-8601) | **Required** | Client time in UTC, e.g. `2025-01-15T18:42:11.123Z`. |
+| `app_version` | string | **Required** | App release version, e.g., `1.2.3`. |
+| `platform` | string | **Required** | Client platform, e.g., `ios`, `android`, `web`. |
+| `device_os_version` | string | **Required** | OS version on the device, e.g., `iOS 17.3`, `Android 14`. |
 
 ## Onboarding events
 
 | Event name | When it fires | Properties (in addition to required common fields) |
 | --- | --- | --- |
-| `onboarding_started` | User begins onboarding flow. | `entry_point` (string, e.g., `first_launch`, `settings`), `app_version` (string), `platform` (string, e.g., `ios`, `android`, `web`). |
+| `onboarding_started` | User begins onboarding flow. | `entry_point` (string, e.g., `first_launch`, `settings`). |
 | `contacts_permission_granted` | OS contacts permission approved. | `permission_status` (string, `granted`), `prompt_type` (string, e.g., `system_prompt`, `settings_redirect`). |
 | `contacts_permission_denied` | OS contacts permission declined. | `permission_status` (string, `denied`), `prompt_type` (string, e.g., `system_prompt`, `settings_redirect`), `denial_reason` (string, optional, e.g., `user_dismissed`, `never_ask_again`). |
 | `contacts_selected_count` | User confirms number of contacts selected during onboarding. | `selected_count` (number), `total_available` (number, optional), `source` (string, e.g., `device_contacts`, `manual_entry`). |


### PR DESCRIPTION
### Motivation
- Ensure every analytics event includes app release and device context for consistent telemetry and easier filtering.

### Description
- Added `app_version`, `platform`, and `device_os_version` as **Required** fields to the "Required common fields (all events)" table in `ANALYTICS_SPEC.md`.
- Removed the now-redundant `app_version` and `platform` properties from the `onboarding_started` event.
- No other event tables were modified.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a6780e5f0832db7c87cf2020ce023)