### PR TITLE
Update TEST_CHECKLIST: add frequency tests and remove unsupported reorder/edit

### DIFF
--- a/ketchup-prototype-mobile-clean/TEST_CHECKLIST.md
+++ b/ketchup-prototype-mobile-clean/TEST_CHECKLIST.md
@@ -34,14 +34,20 @@
 ### List edit
 - [ ] Add a contact to the list and confirm it appears immediately.
 - [ ] Remove a contact and confirm it disappears from the list and selection count updates.
-- [ ] Reorder contacts (if supported) and verify the new order persists in the UI.
-- [ ] Edit contact details and confirm the list reflects updated information.
+
+### Frequency settings
+- [ ] Select each frequency preset and verify the UI reflects the chosen cadence.
+- [ ] Switch between frequency presets and confirm only the latest selection is active.
+- [ ] Enter a custom frequency interval within allowed bounds and verify it is accepted.
+- [ ] Enter a custom frequency interval outside allowed bounds and verify validation messaging.
+- [ ] Enter non-numeric or empty custom intervals and verify input validation behavior.
 
 ### Persistence
 - [ ] Force close and relaunch; verify selected contacts persist.
 - [ ] Reboot device and relaunch; verify selections persist.
 - [ ] Log out/log in (if applicable) and confirm data integrity.
 - [ ] Update app build (same data store) and confirm selections persist.
+- [ ] Set different frequency settings per contact, restart the app, and confirm each contact retains its frequency.
 
 ## Device matrix
 


### PR DESCRIPTION
### Motivation
- The contact reorder/edit items in the checklist are not supported and should be removed to avoid misleading test coverage.
- Frequency-related behavior (presets, custom intervals, and per-contact persistence) needs explicit manual test coverage to validate input handling and data persistence.

### Description
- Removed the `Reorder contacts` and `Edit contact details` checklist items from `TEST_CHECKLIST.md` to reflect unsupported features.
- Added a new "Frequency settings" section with tests to verify selecting each preset, switching presets, and validating custom interval entry within and outside allowed bounds.
- Added a test to validate non-numeric and empty custom interval input behavior.
- Added a persistence test to verify that different frequency settings are retained per contact after restarting the app.

### Testing
- No automated tests were run because this is a documentation-only change to `ketchup-prototype-mobile-clean/TEST_CHECKLIST.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a67827924832d80709709c8e2a035)