### PR TITLE
Add contacts permission blocked-state UX documentation

### DIFF
--- a/ketchup-prototype-mobile-clean/docs/permissions-ux.md
+++ b/ketchup-prototype-mobile-clean/docs/permissions-ux.md
@@ -1,0 +1,10 @@
+# Permissions UX
+
+## Contacts Permission Denied (Blocked State)
+**Headline:** Contacts access is off
+
+**Body copy:** To show your contacts here, enable access in your device settings. We only use your contacts to build your list and never store them without your approval.
+
+**CTA:** Go to Settings
+
+**Return without permission:** If the user comes back without granting contacts access, keep the picker locked and show the same blocked state. The minimum-selection gate stays active (e.g., “Select at least 3 contacts to continue”) and progress remains disabled until permission is granted and the minimum selection is met.


### PR DESCRIPTION
### Motivation
- Standardize the UX messaging and behavior for the contacts-permission blocked state by documenting the headline, explanatory copy, CTA, and the minimum-selection gating behavior when users return without granting access.

### Description
- Add a new documentation file `docs/permissions-ux.md` that includes the blocked-state headline (`Contacts access is off`), body copy, a `Go to Settings` CTA, and guidance that the picker remains locked with the minimum-selection gate active until permission is granted.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a6783bf08832d896c39bb106c19a2)