### PR TITLE
Add curated onboarding, yearly/custom cadence, and per-contact custom intervals

### DIFF
--- a/ketchup-prototype-mobile-clean/ANALYTICS_SPEC.md
+++ b/ketchup-prototype-mobile-clean/ANALYTICS_SPEC.md
@@ -7,9 +7,9 @@
 | `user_id` | string | **Required** | Stable, app-level user identifier. Use the authenticated user ID if available; otherwise a temporary anonymous ID that later resolves to the user. |
 | `session_id` | string | **Required** | Unique per app session (e.g., UUID). Regenerate on cold start or after inactivity timeout. |
 | `timestamp` | string (ISO-8601) | **Required** | Client time in UTC, e.g. `2025-01-15T18:42:11.123Z`. |
-| `app_version` | string | **Required** | App release version, e.g., `1.2.3`. |
-| `platform` | string | **Required** | Client platform, e.g., `ios`, `android`, `web`. |
-| `device_os_version` | string | **Required** | OS version on the device, e.g., `iOS 17.3`, `Android 14`. |
+| `app_version` | string | **Required** | Build version, e.g. `1.0.0 (100)`. |
+| `platform` | string | **Required** | `ios` or `android`. |
+| `device_os_version` | string | **Required** | OS version, e.g. `iOS 17.2`, `Android 13`. |
 
 ## Onboarding events
 

--- a/ketchup-prototype-mobile-clean/RELEASE_READINESS.md
+++ b/ketchup-prototype-mobile-clean/RELEASE_READINESS.md
@@ -1,4 +1,4 @@
-# Release Readiness Notes
+# Release Readiness Notes (v1)
 
 ## App icon + splash
 - **App icon**: Use a simple ketchup bottle glyph in the brand red with a transparent background so it stays crisp on light/dark themes. Provide square 1024×1024 source art for platform tooling.
@@ -10,13 +10,11 @@
 ## Privacy disclosure and permissions copy
 - **Privacy disclosure (store listing/app settings)**:
   - We only collect what we need to make the app work.
-  - Your contacts stay on your device (cloud sync is **post-v1**).
+  - Your curated contacts stay on your device.
   - We do not sell your data or share it with third parties for advertising.
-  - You can request deletion of synced data at any time (**post-v1**).
 - **Permissions copy**:
-  - **Contacts**: “Allow Ketchup to access your contacts to show who you can keep up with. Contacts stay on your device unless you enable sync.”
-  - **Notifications (post-v1)**: “Enable notifications to get reminders when it’s time to catch up.”
-  - **Camera (optional, profile photo)**: “Allow camera access to take a profile photo. Photos are stored locally (cloud sync is **post-v1**).”
+  - **Contacts**: “Allow Ketchup to access your contacts so you can choose who to keep up with. Selected contacts stay on your device.”
+  - **Phone/SMS**: “Allow phone/SMS access to place calls or send texts from Ketchup.”
 
 ## Build signing steps
 - **iOS**:
@@ -32,16 +30,14 @@
   4) Upload the AAB to Google Play Console.
 
 ## Internal testing steps
-1) Run a smoke test on iOS and Android devices (or emulators) to verify onboarding, swipe interactions, and list management flows.
+1) Run a smoke test on iOS and Android devices (or emulators) to verify onboarding and swipe interactions.
 2) Verify permission prompts show the correct copy and that deny/allow paths behave as expected.
-3) Test sync off/on flows to confirm data stays local unless enabled (**post-v1**).
-4) Check UI layout on small and large screens (iPhone SE-class and large Android).
-5) Verify offline behavior for core screens and graceful handling when network is unavailable.
-6) Confirm notifications fire using a short reminder interval (**post-v1**).
+3) Check UI layout on small and large screens (iPhone SE-class and large Android).
+4) Verify offline behavior for core screens and graceful handling when network is unavailable.
 
 ## Feedback collection plan
 - **Internal testers**: Recruit 5–10 testers with a mix of heavy/light contact lists.
 - **Channel**: Use a shared feedback form (e.g., Google Form) and a dedicated Slack/Discord channel for quick notes.
-- **Prompting**: Ask testers to complete a 10-minute task list (onboarding, add contacts, set reminder) and capture any friction.
-- **Metrics**: Track completion rate, time-to-first-reminder, and number of contacts added.
+- **Prompting**: Ask testers to complete a 10-minute task list (onboarding, add contacts, set frequency) and capture any friction.
+- **Metrics**: Track completion rate, time-to-first-action, and number of contacts added.
 - **Iteration**: Triage feedback weekly, fix top 3 issues, and repeat with a new build.

--- a/ketchup-prototype-mobile-clean/TEST_CHECKLIST.md
+++ b/ketchup-prototype-mobile-clean/TEST_CHECKLIST.md
@@ -16,6 +16,12 @@
 - [ ] Deselect a contact to drop below minimum; confirm the app blocks progression and shows feedback.
 - [ ] Select beyond the minimum; verify the app allows extra selections without errors.
 
+### Frequency settings
+- [ ] Choose a preset frequency (weekly, every 2 weeks, monthly, every 3 months, every 6 months, yearly) and confirm it is saved.
+- [ ] Enter a custom interval (days) and confirm it is saved.
+- [ ] Switch from preset to custom (and back) and confirm the UI updates and persists correctly.
+- [ ] Edit frequency post-setup and confirm changes persist.
+
 ### Swipe actions
 - [ ] Swipe right on a contact to trigger the primary action; verify the expected outcome and UI feedback.
 - [ ] Swipe left on a contact to trigger the secondary action; verify expected outcome and UI feedback.
@@ -34,20 +40,13 @@
 ### List edit
 - [ ] Add a contact to the list and confirm it appears immediately.
 - [ ] Remove a contact and confirm it disappears from the list and selection count updates.
-
-### Frequency settings
-- [ ] Select each frequency preset and verify the UI reflects the chosen cadence.
-- [ ] Switch between frequency presets and confirm only the latest selection is active.
-- [ ] Enter a custom frequency interval within allowed bounds and verify it is accepted.
-- [ ] Enter a custom frequency interval outside allowed bounds and verify validation messaging.
-- [ ] Enter non-numeric or empty custom intervals and verify input validation behavior.
+- [ ] Edit frequency and confirm the list reflects updated information.
 
 ### Persistence
 - [ ] Force close and relaunch; verify selected contacts persist.
 - [ ] Reboot device and relaunch; verify selections persist.
 - [ ] Log out/log in (if applicable) and confirm data integrity.
 - [ ] Update app build (same data store) and confirm selections persist.
-- [ ] Set different frequency settings per contact, restart the app, and confirm each contact retains its frequency.
 
 ## Device matrix
 

--- a/ketchup-prototype-mobile-clean/docs/data-model.md
+++ b/ketchup-prototype-mobile-clean/docs/data-model.md
@@ -1,0 +1,23 @@
+# Ketchup v1 Data Model
+
+## Contact
+Represents a device contact selected by the user.
+- **id**: string (stable device contact identifier)
+- **name**: string
+- **phoneNumbers**: string[] (normalized E.164 if possible)
+- **photoUri**: string | null
+
+## KetchupListItem
+Represents a contact included in the user’s curated list.
+- **contactId**: string (foreign key to Contact)
+- **frequencyType**: "preset" | "custom"
+- **frequencyPreset**: "weekly" | "biweekly" | "monthly" | "quarterly" | "semiannual" | "yearly" | null
+- **customIntervalDays**: number | null
+- **createdAt**: ISO-8601 string
+- **updatedAt**: ISO-8601 string
+
+## Interaction (optional v1.1)
+Captures user actions for future prioritization.
+- **contactId**: string
+- **type**: "swipe_left" | "swipe_right" | "call" | "text"
+- **timestamp**: ISO-8601 string

--- a/ketchup-prototype-mobile-clean/docs/engineering-backlog.md
+++ b/ketchup-prototype-mobile-clean/docs/engineering-backlog.md
@@ -1,0 +1,41 @@
+# Ketchup v1 Engineering Backlog
+
+## Epic 1: Project setup (2–3 days)
+- Initialize Expo app with TypeScript.
+- Add navigation + gesture libraries.
+- Configure linting/formatting.
+- Document local run steps (iOS/Android).
+
+## Epic 2: Contact import + permissions (4–6 days)
+- Implement permission prompt + blocked state.
+- Integrate native contact picker (multi-select).
+- Enforce minimum contact selection (>=5).
+- Normalize contact data into local model.
+
+## Epic 3: Frequency settings (3–5 days)
+- Preset selector UI + custom interval input.
+- Persist per-contact frequency settings.
+- Edit frequency post-setup.
+
+## Epic 4: Swipe deck + actions (5–7 days)
+- Swipe card UI with left/right gestures.
+- Reveal call/text actions on right swipe.
+- Handle missing phone numbers.
+
+## Epic 5: Manage list (3–5 days)
+- Add contacts from picker.
+- Remove contacts from list.
+- Update frequency from list.
+
+## Epic 6: Analytics instrumentation (2–3 days)
+- Implement onboarding, swipe, action, and list edit events.
+- Add common metadata to all events.
+
+## Epic 7: QA + pre-beta readiness (3–5 days)
+- Execute functional + regression tests.
+- Validate persistence across restarts.
+- Device matrix testing (iOS 16/17, Android 12/13).
+
+## Dependencies
+- Contact permissions + picker before onboarding completion.
+- Local storage before list management + swipe deck.

--- a/ketchup-prototype-mobile-clean/docs/execution-plan.md
+++ b/ketchup-prototype-mobile-clean/docs/execution-plan.md
@@ -1,0 +1,50 @@
+# Ketchup v1 Execution Plan
+
+## Goal
+Turn the v1 PRD into a build-ready plan with clear owners, milestones, and concrete deliverables.
+
+## Phase 0: Kickoff (1–2 days)
+- Confirm v1 scope and acceptance criteria in `docs/v1-prd.md`.
+- Review UX flows in `docs/v1-ux-flows.md` and align on screen list.
+- Assign owners for mobile engineering, design, and QA.
+- Define a 2–3 week sprint cadence and weekly demo time.
+
+## Phase 1: Repo + Architecture (2–3 days)
+- Initialize Expo RN repo with TypeScript.
+- Add navigation, gesture, and animation libraries.
+- Set up linting/formatting and basic CI (lint + typecheck).
+- Document local run steps.
+
+## Phase 2: Core Data + Contacts (4–6 days)
+- Implement native contact picker with permissions.
+- Enforce minimum selection (>=5) with validation UI.
+- Normalize and persist selected contacts locally.
+
+## Phase 3: Frequency + List Management (3–5 days)
+- Preset frequency UI + custom interval input.
+- Persist frequency per contact.
+- Add/manage list post-setup (add/remove/edit frequency).
+
+## Phase 4: Swipe + Actions (5–7 days)
+- Swipe card UI with left/right gestures.
+- Reveal call/text actions on right swipe.
+- Handle missing phone numbers gracefully.
+
+## Phase 5: Analytics + QA (3–5 days)
+- Instrument onboarding, swipe, and actions per `ANALYTICS_SPEC.md`.
+- Execute manual QA in `TEST_CHECKLIST.md`.
+- Fix top issues and prepare pre-beta build.
+
+## Deliverables by phase
+- **Phase 1:** Repo + build instructions.
+- **Phase 2:** Contact import + local storage working.
+- **Phase 3:** Frequency settings + list management.
+- **Phase 4:** Swipe flow + call/text actions.
+- **Phase 5:** Analytics + pre-beta readiness.
+
+## Weekly demo checklist
+- Onboarding completion with minimum selection.
+- Frequency setting + edit persistence.
+- Swipe interactions + call/text actions.
+- List edits reflected in swipe deck.
+

--- a/ketchup-prototype-mobile-clean/docs/mobile-architecture.md
+++ b/ketchup-prototype-mobile-clean/docs/mobile-architecture.md
@@ -1,68 +1,53 @@
-# Mobile Architecture (Proposed)
+# Mobile Architecture (v1)
 
 ## Platform Decision
-**Recommendation: React Native (Expo).**
-- Best fit for a mobile-first contact picker + swipe UI experience while keeping velocity high.
-- Access to native contacts (iOS/Android) and local storage options with first-party/maintained libraries.
-- Expo provides faster iteration and OTA updates; can eject later if deeper native integrations are needed.
+**React Native (Expo).**
+- Best fit for iOS + Android delivery with a native contact picker and swipe UI.
+- High iteration speed with Expo; can eject later if deeper native integrations are required.
 
-**Alternatives considered**
-- **Flutter:** Strong UI performance, but higher learning curve for the existing React stack and less direct code reuse.
-- **Capacitor + React Web:** Faster reuse of web code, but contact access + swipe performance can be less consistent on low-end devices.
+## Repo Setup (v1)
+- Initialize Expo app with TypeScript.
+- Add navigation (`@react-navigation/native`).
+- Add gesture handling + animation (`react-native-gesture-handler`, `react-native-reanimated`).
+- Configure linting/formatting (ESLint + Prettier).
+- Document local run steps for iOS + Android.
 
 ## Contact Picker Integration Approach
-- **Primary:** Use Expo Contacts for permission + fetch contacts.
-  - `expo-contacts` handles platform permissions and normalized contact retrieval.
-  - Filter/normalize to the app’s internal `Contact` model (name, phone numbers, avatar).
-- **Fallback / Advanced:** If deeper native access is needed (e.g., iOS CNContactStore tuning), eject to bare RN and use `react-native-contacts`.
+- **Primary:** `expo-contacts` for permissions + contact retrieval.
+- Normalize contacts into internal `Contact` model:
+  - `id`, `name`, `phoneNumbers`, `photoUri`.
 
 ## Local Storage Strategy
-- **Default (MVP):** AsyncStorage for lightweight key-value data
-  - Stores user preferences, onboarding completion, and cached “recently viewed” contact IDs.
-- **Structured / Offline Cache:** SQLite (via `expo-sqlite`)
-  - Stores contact metadata, interaction history, tags, and “swipe decisions.”
-  - Enables fast querying for analytics without network dependency (“Up Next” is **post-v1**).
+- **MVP:** `AsyncStorage` for lightweight preferences and onboarding flags.
+- **Structured data:** `expo-sqlite` for contacts + frequency settings.
 
-## Navigation Structure
-- **Library:** `@react-navigation/native`
-- **Pattern:**
-  - **Root Stack**
-    - `Onboarding` (stack)
-    - `Main` (tab)
-  - **Main Tabs**
-    - `Home` (swipe cards)
-    - `Lists` (list management)
-    - `Profile/Settings`
-  - **Nested Details**
-    - `ContactDetail` pushed from Home/Lists
+## Navigation Structure (v1)
+- **Root Stack**
+  - Onboarding (stack)
+  - Main (stack)
+- **Main Stack**
+  - Swipe Deck (home)
+  - Manage List
+  - Contact Detail (optional)
 
 ## Swipe UI Library
-- **Recommendation:** `react-native-gesture-handler` + `react-native-reanimated` (custom swipe card)
-  - Highest performance, full control of gestures and animations.
-  - Can recreate the web prototype behavior (edge-to-edge card, swipe actions, velocity thresholds).
-- **Alternative:** `react-native-deck-swiper`
-  - Faster to start but less flexible; may struggle with custom physics/stacking.
+- **Recommendation:** `react-native-gesture-handler` + `react-native-reanimated` (custom deck).
 
-## One-Page Architecture Outline (Text Diagram)
+## Architecture Outline (Text Diagram)
 
 ```
 [Expo App]
    |
    |-- UI Layer
-   |     |-- Swipe Deck (gesture-handler + reanimated)
-   |     |-- List Management
-   |     |-- Contact Detail
+   |     |-- Swipe Deck
+   |     |-- Manage List
    |
-   |-- Navigation Layer (@react-navigation)
-   |     |-- Root Stack (Onboarding -> Main Tabs)
-   |     |-- Tabs (Home | Lists | Settings)
+   |-- Navigation Layer
+   |     |-- Root Stack (Onboarding -> Main)
    |
    |-- Data Layer
-   |     |-- Contact Service (expo-contacts)
+   |     |-- Contacts Service (expo-contacts)
    |     |-- Local Store
    |           |-- AsyncStorage (prefs, flags)
-   |           |-- SQLite (contacts, interactions)
-   |
-   |-- Optional Cloud Sync (**post-v1**)
-         |-- Supabase (auth + sync when online)
+   |           |-- SQLite (contacts, frequencies)
 ```

--- a/ketchup-prototype-mobile-clean/docs/v1-prd.md
+++ b/ketchup-prototype-mobile-clean/docs/v1-prd.md
@@ -1,0 +1,85 @@
+# Ketchup v1 PRD
+
+## 1. Overview
+**Product name:** Ketchup  
+**Mission:** Help people stay connected by surfacing the right person at the right time during spare moments.  
+**Platforms:** iOS + Android (React Native / Expo).  
+**Primary metric:** Weekly Active Users (WAU).
+
+## 2. Target user & use case
+**Target user:** Busy people who want to maintain relationships but often forget to reach out.  
+**Core scenario:** During a free moment, a user opens Ketchup, swipes through a curated list of contacts, and chooses someone to call or text.
+
+## 3. Objectives & success metrics
+**Primary:** WAU growth post-launch.  
+**Secondary:**
+- Onboarding completion rate.
+- Avg. contacts added per user.
+- % of sessions with at least one call/text action.
+
+## 4. MVP scope (v1)
+### Must-have
+1. Account setup (lightweight for v1; device-scoped identity is acceptable).
+2. Curated contact import using native contact picker.
+3. Minimum selection requirement (e.g., at least 5 contacts).
+4. Per-contact frequency selection:
+   - Presets: weekly, every 2 weeks, monthly, every 3 months, every 6 months, yearly.
+   - Custom interval input (days).
+5. Swipe card experience:
+   - Swipe left = skip.
+   - Swipe right = reveal call/text actions.
+6. Call or text actions (open native dialer/SMS composer).
+7. Manage list post-setup (add/remove contacts, edit frequency).
+
+### Out of scope (explicit)
+- Social data ingestion (Gmail/LinkedIn/Instagram).
+- External event-based prioritization.
+- Cloud sync across devices.
+- Notifications/reminders (planned for later).
+
+## 5. UX flows
+### Onboarding
+1. Welcome → “Get started”.
+2. Contact permission prompt.
+3. Native contact picker (multi-select).
+4. Validation: require minimum contact count to proceed.
+5. Frequency selection (bulk or per contact).
+6. Confirmation → enter swipe flow.
+
+### Swipe flow
+- Show contact card (name, photo, primary phone).  
+- Swipe left: skip.  
+- Swipe right: reveal call/text action buttons.  
+- Tap call/text: open native apps.
+
+### Manage list
+- Add/remove contacts via picker.
+- Edit frequency per contact.
+
+## 6. Functional requirements
+- Import only selected contacts.
+- Enforce minimum contact count.
+- Allow frequency presets + custom intervals.
+- Persist selections and frequency locally.
+- Provide call/text actions even if frequency isn’t “due.”
+- Handle missing phone numbers with disabled action or clear error.
+
+## 7. Non-functional requirements
+- Responsive swipe performance (60 FPS target on mid-tier devices).
+- Graceful permission denial handling with “Go to Settings” CTA.
+- Offline-first behavior for core flows.
+
+## 8. Risks & mitigations
+- **Permission denial:** Provide blocked state + Settings CTA.
+- **Contact overload:** Require minimum, encourage curated list.
+- **Frequency confusion:** Inline helper text and presets.
+
+## 9. Acceptance criteria (v1)
+- User can complete onboarding after selecting >= minimum contacts.
+- User can set frequency presets/custom interval for each contact.
+- User can swipe through list and trigger call/text actions.
+- User can add/remove contacts and edit frequency after onboarding.
+- App persists list and preferences across restarts.
+
+## 10. Testing plan (v1)
+See `TEST_CHECKLIST.md` for functional/regression coverage and device matrix.

--- a/ketchup-prototype-mobile-clean/docs/v1-ux-flows.md
+++ b/ketchup-prototype-mobile-clean/docs/v1-ux-flows.md
@@ -1,0 +1,48 @@
+# Ketchup v1 UX Flows
+
+## 1) Onboarding (curated contacts)
+**Goal:** Build a curated Ketchup list with a minimum number of contacts and assign frequencies.
+
+1. **Welcome**
+   - CTA: “Get started”.
+2. **Contacts permission prompt**
+   - Copy: “Allow Ketchup to access your contacts so you can choose who to keep up with.”
+   - Secondary: “Not now” → blocked state.
+3. **Blocked state (permission denied)**
+   - Header: “Contacts access required”.
+   - Body: “Ketchup only uses selected contacts. Enable access to continue.”
+   - CTA: “Go to Settings”.
+4. **Contact picker (native)**
+   - Multi-select; show selected count.
+   - **Validation:** “Select at least 5 contacts to continue.”
+5. **Frequency selection**
+   - Option A: bulk preset for all, then per-contact edit.
+   - Option B: per-contact inline selector.
+   - Presets + custom interval (days).
+6. **Confirmation**
+   - Summary of selected contacts + frequencies.
+   - CTA: “Start swiping”.
+
+## 2) Swipe flow
+**Goal:** Let users quickly decide who to reach out to.
+
+- Card shows name, photo, primary phone.
+- Swipe left: skip.
+- Swipe right: reveal actions.
+- Actions:
+  - **Call** → open native dialer.
+  - **Text** → open native SMS composer.
+- Missing phone: disable action with tooltip (“No phone number available”).
+
+## 3) Manage list (post-setup)
+**Goal:** Edit curated list and frequencies.
+
+- **Add contact** → native picker.
+- **Remove contact** → remove from list + deck.
+- **Edit frequency** → presets + custom interval.
+
+## 4) Edge cases
+- Fewer than minimum selected → block progression.
+- Permission denied → blocked state + Settings CTA.
+- Contact without phone number → action disabled.
+- Duplicate phone numbers → normalize and choose primary.


### PR DESCRIPTION
### Motivation
- Replace the lightweight demo onboarding with a curated multi-step flow that enforces a minimum contact selection so users start with a useful list.
- Add richer cadence options (yearly + custom intervals) and persist those per-contact so prioritization and due calculations match product acceptance criteria.

### Description
- Replace single-step onboarding with a three-step `Onboarding` flow (`profile` → `select` → `frequency`) that requires selecting at least 5 contacts and allows setting a default cadence before entering the app.
- Add `yearly` preset and a `custom` option to `FREQUENCIES`, introduce `customIntervalDays` on `Contact`, and wire a new helper `getCadenceDays` so scoring and `nextDueDays` respect custom intervals.
- Extend UI: `FrequencySelect` includes `Custom`, `PersonRow` shows a numeric input when a contact uses a custom cadence, and `SwipeCard`/lists display a friendly label for custom cadence.
- Persist custom cadence to storage and Supabase mappings (`custom_interval_days`), update seed data with additional demo contacts, and remove the onboarding notification nudge code and related UI copy.

### Testing
- Started the dev server (`npm run dev`) and confirmed Vite served the app successfully (local: `http://localhost:4173/`).
- Ran a Playwright script to exercise onboarding (filled name, progressed to contact selection) and captured a screenshot; the script ran to completion and produced an onboarding selection artifact.
- No unit tests were added; end-to-end smoke check above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698630ae3ed0832da323b0c3b4659c60)